### PR TITLE
PDP-1202 & PDP-1128

### DIFF
--- a/charts/dp-configure-namespace/Chart.yaml
+++ b/charts/dp-configure-namespace/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: dp-configure-namespace
 description: A Helm chart for creating service account, cluster-role, cluster-role-binding, role-binding & network-policies
 type: application
-version: 1.0.11
+version: 1.0.12
 appVersion: "1.0.0"

--- a/charts/dp-configure-namespace/README.md
+++ b/charts/dp-configure-namespace/README.md
@@ -1,13 +1,13 @@
 ## Use-case 1:
 
-Customer has created new namespace and applied the Tibco platform dataPlane labels.
-Customer now wants to create new service-account, cluster-role, cluster-role-binding and role-binding
+Customer has created new primary namespace and applied the Tibco platform dataPlane label.
+Customer now wants to create new service-account, cluster-role, cluster-role-binding, role-binding & (optional) network policies.
 
 #  Release Namespace and Primary Namespace
 .Release.Namespace is same as .Values.global.tibco.primaryNamespaceName.
-So, service-account is created in this namespace, which will be referred in the subsequent application namespace configuration.
+So, service-account is created in this namespace, which will be referred in the subsequent application namespace(s) configuration.
 
-# sample payload
+# Sample values
 global:
   tibco:
     dataPlaneId: "abcd" # Mandatory
@@ -16,26 +16,28 @@ global:
 
 createServiceAccount: true # Default true
 
-createNetworkPolicy: true # Default true
-additionalNetworkPolicy: {}
+createNetworkPolicy: false # Default false, set to true to enable network policies
+nodeCidrIpBlock: "" # If createNetworkPolicy above is true, node CIDR IP block is required
+podCidrIpBlock: "" # If createNetworkPolicy above is true & pod CIDR IP block is different from nodeCidrIpBlock, then podCidrIpBlock is required. Otherwise, it will be set equal to nodeCidrIpBlock
 
 ## Use-case 2:
 
 Customer has created new application namespace and applied the Tibco platform dataPlane labels.
 The cluster-roles, cluster-role-binidng are present and service-account in primary namespace is to be used.
-To enable application deployment Customer needs to create role-binding in the new namespace.
+To enable application deployment Customer needs to create role-binding and network policies in the new namespace.
 
 #  Release Namespace and Primary Namespace
 .Release.Namespace is NOT same as .Values.global.tibco.primaryNamespaceName.
-So, only role-binding is created in this namespace.
+So, only role-binding and (optional) network policies are created in this namespace.
 Service Account is used from the primaryNamespaceName.
 
-# set of global values to obtain the details of service account, dataPlane id and primary namespace
+# Sample values
 global:
   tibco:
     dataPlaneId: "abcd" # Mandatory
     primaryNamespaceName: "dp-namespace" # Mandatory
     serviceAccount: "sa" # Mandatory
 
-createNetworkPolicy: true # Default true
-additionalNetworkPolicy: {}
+createNetworkPolicy: false # Default false, set to true to enable network policies
+nodeCidrIpBlock: "" # If createNetworkPolicy above is true, node CIDR IP block is required
+podCidrIpBlock: "" # If createNetworkPolicy above is true & pod CIDR IP block is different from nodeCidrIpBlock, then podCidrIpBlock is required. Otherwise, it will be set equal to nodeCidrIpBlock

--- a/charts/dp-configure-namespace/templates/NOTES.txt
+++ b/charts/dp-configure-namespace/templates/NOTES.txt
@@ -1,4 +1,5 @@
-{{ include "dp-configure-namespace.nodeCidr" . }}
+Node CIDR: {{ include "dp-configure-namespace.nodeCidr" . }}
+Pod CIDR: {{ include "dp-configure-namespace.podCidr" . }}
 {{ include "dp-configure-namespace.validate-namespace" . }}
 Release name: {{ .Release.Name }}.
 To learn more about the release, try:

--- a/charts/dp-configure-namespace/templates/NOTES.txt
+++ b/charts/dp-configure-namespace/templates/NOTES.txt
@@ -1,7 +1,16 @@
+{{- include "dp-configure-namespace.validate-namespace" . }}
+{{- if .Values.networkPolicy.create -}}
 Node CIDR: {{ include "dp-configure-namespace.nodeCidr" . }}
 Pod CIDR: {{ include "dp-configure-namespace.podCidr" . }}
-{{ include "dp-configure-namespace.validate-namespace" . }}
-Release name: {{ .Release.Name }}.
+{{- if eq (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+To use a different Pod CIDR, please use --set networkPolicy.podCidrIpBlock=<PodIpCidr>
+PodIpCidr=<IP range of Pod IP CIDR (CIDR notation)> e.g. 192.168.0.0/16
+{{- end }}
+{{- else }}
+Network policies creation is disabled by default.
+To enable network policies creation, please use --set networkPolicy.create=true
+{{- end }}
+Release name: {{ .Release.Name }}
 To learn more about the release, try:
   $ helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
   $ helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}

--- a/charts/dp-configure-namespace/templates/_helpers.tpl
+++ b/charts/dp-configure-namespace/templates/_helpers.tpl
@@ -60,7 +60,7 @@ Create chart name and version as used by the chart label.
 {{/* Node Cidr for the cluster */}}
 {{- define "dp-configure-namespace.nodeCidr" }}
 {{- if .Values.networkPolicy.create }}
-{{- required (printf "networkPolicy.nodeCidrIpBlock is required, if Network Policy is enabled.\nIf Node CIDR and Pod CIDR are different, both need to be passed from values.\nOtherwise same values will be used for .networkPolicy.nodeCidrIpBlock and .networkPolicy.podCidrIpBlock.\n\nUse --set networkPolicy.nodeCidrIpBlock=<NodeIpCidr>\nNodeIpCidr=<IP range of Nodes VPC or VNet address space (CIDR notation)> e.g. 10.200.0.0/16\n\nUse --set networkPolicy.podCidrIpBlock=<PodIpCidr>\nPodIpCidr=<IP range of Pod IP CIDR (CIDR notation)> e.g. 10.192.0.0/16") .Values.networkPolicy.nodeCidrIpBlock -}}
+{{- required (printf "networkPolicy.nodeCidrIpBlock is required, if Network Policy is enabled.\nIf Node CIDR and Pod CIDR are different, both need to be passed from values.\nOtherwise same values will be used for .networkPolicy.nodeCidrIpBlock and .networkPolicy.podCidrIpBlock.\n\nUse --set networkPolicy.nodeCidrIpBlock=<NodeIpCidr>\nNodeIpCidr=<IP range of Nodes VPC or VNet address space (CIDR notation)> e.g. 10.200.0.0/16\n\nUse --set networkPolicy.podCidrIpBlock=<PodIpCidr>\nPodIpCidr=<IP range of Pod IP CIDR (CIDR notation)> e.g. 192.168.0.0/16") .Values.networkPolicy.nodeCidrIpBlock -}}
 {{- end }}
 {{- end }}
 

--- a/charts/dp-configure-namespace/templates/_helpers.tpl
+++ b/charts/dp-configure-namespace/templates/_helpers.tpl
@@ -60,7 +60,18 @@ Create chart name and version as used by the chart label.
 {{/* Node Cidr for the cluster */}}
 {{- define "dp-configure-namespace.nodeCidr" }}
 {{- if .Values.networkPolicy.create }}
-{{- required (printf "networkPolicy.nodeCidrIpBlock is required, if Network Policy is enabled.\nUse --set networkPolicy.nodeCidrIpBlock=<NodeIpCidr>\nNodeIpCidr=<IP range of Nodes VPC or VNet address space (CIDR notation)> e.g. 10.200.0.0/16") .Values.networkPolicy.nodeCidrIpBlock -}}
+{{- required (printf "networkPolicy.nodeCidrIpBlock is required, if Network Policy is enabled.\nIf Node CIDR and Pod CIDR are different, both need to be passed from values.\nOtherwise same values will be used for .networkPolicy.nodeCidrIpBlock and .networkPolicy.podCidrIpBlock.\n\nUse --set networkPolicy.nodeCidrIpBlock=<NodeIpCidr>\nNodeIpCidr=<IP range of Nodes VPC or VNet address space (CIDR notation)> e.g. 10.200.0.0/16\n\nUse --set networkPolicy.podCidrIpBlock=<PodIpCidr>\nPodIpCidr=<IP range of Pod IP CIDR (CIDR notation)> e.g. 10.192.0.0/16") .Values.networkPolicy.nodeCidrIpBlock -}}
+{{- end }}
+{{- end }}
+
+{{/* Pod Cidr for the cluster */}}
+{{- define "dp-configure-namespace.podCidr" }}
+{{- if .Values.networkPolicy.create }}
+{{- if empty .Values.networkPolicy.podCidrIpBlock }}
+{{- .Values.networkPolicy.nodeCidrIpBlock }}
+{{- else }}
+{{- .Values.networkPolicy.podCidrIpBlock }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/dp-configure-namespace/templates/network-policy.yaml
+++ b/charts/dp-configure-namespace/templates/network-policy.yaml
@@ -76,6 +76,9 @@ spec:
         cidr: 0.0.0.0/0
         except:
         - {{ include "dp-configure-namespace.nodeCidr" . }}
+        {{- if ne (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+        - {{ include "dp-configure-namespace.podCidr" . }}
+        {{- end }}
 
 ---
 
@@ -100,6 +103,9 @@ spec:
         cidr: 0.0.0.0/0
         except:
         - {{ include "dp-configure-namespace.nodeCidr" . }}
+        {{- if ne (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+        - {{ include "dp-configure-namespace.podCidr" . }}
+        {{- end }}
     ports:
     - protocol: TCP
       port: 80
@@ -132,6 +138,10 @@ spec:
           component: kube-apiserver
     - ipBlock:
         cidr: {{ include "dp-configure-namespace.nodeCidr" . }}
+    {{- if ne (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+    - ipBlock:
+        cidr: {{ include "dp-configure-namespace.podCidr" . }}
+    {{- end }}
     ports:
     - protocol: TCP
       port: 443
@@ -145,6 +155,10 @@ spec:
           component: kube-apiserver
     - ipBlock:
         cidr: {{ include "dp-configure-namespace.nodeCidr" . }}
+    {{- if ne (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+    - ipBlock:
+        cidr: {{ include "dp-configure-namespace.podCidr" . }}
+    {{- end }}
 
 ---
 
@@ -168,6 +182,9 @@ spec:
         cidr: 0.0.0.0/0
         except:
         - {{ include "dp-configure-namespace.nodeCidr" . }}
+        {{- if ne (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+        - {{ include "dp-configure-namespace.podCidr" . }}
+        {{- end }}
 
 ---
 
@@ -189,5 +206,8 @@ spec:
   - from:
     - ipBlock:
         cidr: {{ include "dp-configure-namespace.nodeCidr" . }}
-
+    {{- if ne (include "dp-configure-namespace.nodeCidr" . ) (include "dp-configure-namespace.podCidr" . ) }}
+    - ipBlock:
+        cidr: {{ include "dp-configure-namespace.podCidr" . }}
+    {{- end }}
 {{- end -}}

--- a/charts/dp-configure-namespace/values.yaml
+++ b/charts/dp-configure-namespace/values.yaml
@@ -14,11 +14,11 @@ createServiceAccount: true
 
 networkPolicy:
   # Flag to enable or disable creating default network policies for a namespace
-  # Default value is true. Possible values are true, false
-  create: true
+  # Default value is false. Possible values are true, false
+  create: false
   # Required value if the network policies are to be enabled
   # node CIDR IP block
-  nodeCidrIpBlock: "10.200.0.0/16"
+  nodeCidrIpBlock: ""
   # pod CIDR IP block
-  podCidrIpBlock: "10.192.0.0/16"
+  podCidrIpBlock: ""
   

--- a/charts/dp-configure-namespace/values.yaml
+++ b/charts/dp-configure-namespace/values.yaml
@@ -16,7 +16,9 @@ networkPolicy:
   # Flag to enable or disable creating default network policies for a namespace
   # Default value is true. Possible values are true, false
   create: true
-  # node CIDR IP block
   # Required value if the network policies are to be enabled
-  nodeCidrIpBlock: ""
+  # node CIDR IP block
+  nodeCidrIpBlock: "10.200.0.0/16"
+  # pod CIDR IP block
+  podCidrIpBlock: "10.192.0.0/16"
   


### PR DESCRIPTION
PDP-1202 Add pod cidr in kubernetes api network policy
1. helm upgrade --install -n default --dry-run dp-configure-namespace dp-configure-namespace/ --set networkPolicy.create=false
```
NOTES:
Network policies creation is disabled by default.
To enable network policies creation, please use --set networkPolicy.create=true
```

Given that network policy is enabled:
1. helm upgrade --install -n default --dry-run dp-configure-namespace dp-configure-namespace/ --set networkPolicy.create=true (fails validation)
```
networkPolicy.nodeCidrIpBlock is required, if Network Policy is enabled.
If Node CIDR and Pod CIDR are different, both need to be passed from values.
Otherwise same values will be used for .networkPolicy.nodeCidrIpBlock and .networkPolicy.podCidrIpBlock.

Use --set networkPolicy.nodeCidrIpBlock=<NodeIpCidr>
NodeIpCidr=<IP range of Nodes VPC or VNet address space (CIDR notation)> e.g. 10.200.0.0/16

Use --set networkPolicy.podCidrIpBlock=<PodIpCidr>
PodIpCidr=<IP range of Pod IP CIDR (CIDR notation)> e.g. 10.192.0.0/16
```
2. helm upgrade --install -n default --dry-run dp-configure-namespace dp-configure-namespace/ --set networkPolicy.create=true --set networkPolicy.nodeCidrIpBlock="10.200.0.0/16"

```
NOTES:
Node CIDR: 10.200.0.0/16
Pod CIDR: 10.200.0.0/16
To use a different Pod CIDR, please use --set networkPolicy.podCidrIpBlock=<PodIpCidr>
PodIpCidr=<IP range of Pod IP CIDR (CIDR notation)> e.g. 10.192.0.0/16
```
3. helm upgrade --install -n default --dry-run dp-configure-namespace dp-configure-namespace/ --set networkPolicy.create=true --set networkPolicy.podCidrIpBlock="192.168.0.0/16"
Same error (1) above (fails validation)

4. helm upgrade --install -n default --dry-run dp-configure-namespace dp-configure-namespace/ --set networkPolicy.create=true --set networkPolicy.nodeCidrIpBlock="10.200.0.0/16" --set networkPolicy.podCidrIpBlock="192.168.0.0/16"

```
NOTES:
Node CIDR: 10.200.0.0/16
Pod CIDR: 192.168.0.0/16
```