### PR TITLE
Refs #EIN-11688 Move imagePullSecrets to under spec.

### DIFF
--- a/charts/istio-crd/Chart.yaml
+++ b/charts/istio-crd/Chart.yaml
@@ -11,4 +11,4 @@ keywords:
 name: istio-crd
 sources:
 - https://github.com/istio/istio
-version: 1.0.17
+version: 1.0.18

--- a/charts/istio-istiod/Chart.yaml
+++ b/charts/istio-istiod/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
 name: istio-istiod
 sources:
 - https://github.com/istio/istio
-version: 1.0.17
+version: 1.0.18

--- a/charts/istio-istiod/templates/deployment.yaml
+++ b/charts/istio-istiod/templates/deployment.yaml
@@ -107,6 +107,10 @@ spec:
 {{- end }}
       securityContext:
         fsGroup: 1337
+{{- if .Values.global.cp.containerRegistry.secret }}
+      imagePullSecrets:
+        - name: {{ .Values.global.cp.containerRegistry.secret }}
+{{- end }}
       containers:
         - name: discovery
 {{- if contains "/" .Values.pilot.image }}
@@ -116,10 +120,6 @@ spec:
 {{- end }}
 {{- if .Values.global.imagePullPolicy }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-{{- end }}
-{{- if .Values.global.cp.containerRegistry.secret }}
-          imagePullSecrets:
-            - name: {{ .Values.global.cp.containerRegistry.secret }}
 {{- end }}
           args:
           - "discovery"


### PR DESCRIPTION
Moving imagePullSecrets to under spec.
imagePullSecrets should be under spec and not container.
Otherwise, it is causing deployment on jfrog to fail.
