### PR TITLE
msgdp-260: EMS-Container-image must contain actual PIMS license.txt file

### DIFF
--- a/charts/msg-ems-tp/Chart.yaml
+++ b/charts/msg-ems-tp/Chart.yaml
@@ -1,14 +1,14 @@
 #
 # Copyright (c) 2023. Cloud Software Group, Inc.
-# This file is subject to the license terms contained
-# in the license file that is distributed with this file.
+# This file is subject to the license terms contained 
+# in the license file that is distributed with this file.  
 #
 
 apiVersion: v2
-appVersion: "10.2.1-8"
+appVersion: "10.2.1-9"
 description: Data-plane provisioning chart for EMS server group
 name: msg-ems-tp
-version: "1.0.22"
+version: "1.0.23"
 keywords:
 - tibco-platform
 - data-plane

--- a/charts/msg-ems-tp/Chart.yaml
+++ b/charts/msg-ems-tp/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2023. Cloud Software Group, Inc.
-# This file is subject to the license terms contained 
-# in the license file that is distributed with this file.  
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
 #
 
 apiVersion: v2

--- a/charts/msg-ems-tp/docs/analyzing-ems-image-thirdparty.md
+++ b/charts/msg-ems-tp/docs/analyzing-ems-image-thirdparty.md
@@ -1,0 +1,190 @@
+# Analyzing container images and their associated licenses
+
+This document describes how to analyze container images for software artifacts and associated licenses.
+
+## Base container image
+
+This project uses a [Ubuntu](https://hub.docker.com/_/ubuntu) [official container](https://hub.docker.com/_/ubuntu) LTS image as the common base image layer for building images.
+
+See the [license information](https://ubuntu.com/legal/open-source-licences?release=jammy) for details on Ubuntu licenses and software package types.
+
+As with all container images, the Debian container image can contain other software (such as `bash`, `glibc`, `zlib`, and others from the base distribution, along with any direct or indirect dependencies of the primary software included in the built image) that might be subjected to other licenses.
+
+The following links provide auto-detected license information for the Ubuntu official images:
+
+- [ubuntu](https://github.com/docker-library/repo-info/tree/master/repos/ubuntu)
+    - [local](https://github.com/docker-library/repo-info/blob/master/repos/ubuntu/local)
+    - [remote](https://github.com/docker-library/repo-info/blob/master/repos/ubuntu/remote)
+
+For example, you can find information about the artifacts of the [ubuntu:22.04](https://github.com/docker-library/repo-info/blob/master/repos/ubuntu/local/22.04.md) official image.
+
+**Note**: The image user has the responsibility to ensure that any use of the image complies with all relevant licenses for all software contained within.
+
+## Additional software packages
+
+Building images often installs additional software packages (fetched from the official distribution software repositories, from other user added repositories, or from specific locations), in addition to the packages already provided by the base image.
+Each such specified package can, in turn, install other software packages as dependencies.
+
+**Note**: There are different ways to extract the list of installed packages and other installed artifacts.
+Providing detailed instructions on software license analysis specialized tools is outside the scope of this document.
+Retrieving information on software artifacts other than software packages installed with the package manager tools is also outside the scope of this document.
+The following sections provide basic examples using standard container and package management tools.
+
+### Manually retrieve installed packages information
+
+You can use the command `dpkg-query` to retrieve the full list of installed packages in a container image.
+
+**Example**: To retrieve the list of installed packages in the `ubuntu:22.04` image:
+```bash
+$ docker run --rm ubuntu:22.04 dpkg-query -l
+```
+**Result**:
+```
+> docker run --rm ubuntu:22.04 dpkg-query -l
+Unable to find image 'ubuntu:22.04' locally
+22.04: Pulling from library/ubuntu
+aece8493d397: Already exists
+Digest: sha256:2b7412e6465c3c7fc5bb21d3e6f1917c167358449fecac8176c6e496e5c1f05f
+Status: Downloaded newer image for ubuntu:22.04
+Desired=Unknown/Install/Remove/Purge/Hold
+| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+||/ Name                    Version                                 Architecture Description
++++-=======================-=======================================-============-========================================================================
+ii  adduser                 3.118ubuntu5                            all          add and remove users and groups
+ii  apt                     2.4.10                                  amd64        commandline package manager
+ii  base-files              12ubuntu4.4                             amd64        Debian base system miscellaneous files
+ii  base-passwd             3.5.52build1                            amd64        Debian base system master password and group files
+ii  bash                    5.1-6ubuntu1                            amd64        GNU Bourne Again SHell
+ii  bsdutils                1:2.37.2-4ubuntu3                       amd64        basic utilities from 4.4BSD-Lite
+ii  coreutils               8.32-4.1ubuntu1                         amd64        GNU core utilities
+ii  dash                    0.5.11+git20210903+057cd650a4ed-3build1 amd64        POSIX-compliant shell
+ii  debconf                 1.5.79ubuntu1                           all          Debian configuration management system
+ii  debianutils             5.5-1ubuntu2                            amd64        Miscellaneous utilities specific to Debian
+ii  diffutils               1:3.8-0ubuntu2                          amd64        File comparison utilities
+ii  dpkg                    1.21.1ubuntu2.2                         amd64        Debian package management system
+ii  e2fsprogs               1.46.5-2ubuntu1.1                       amd64        ext2/ext3/ext4 file system utilities
+ii  findutils               4.8.0-1ubuntu3                          amd64        utilities for finding files--find, xargs
+ii  gcc-12-base:amd64       12.3.0-1ubuntu1~22.04                   amd64        GCC, the GNU Compiler Collection (base package)
+...
+```
+
+### Manually retrieve installed packages licenses
+
+You can use the command `dpkg` to retrieve the license for any installed package.
+
+**Example**: To retrieve the license information for the installed package `apt`:
+```bash
+docker run --rm ubuntu:22.04  bash -c 'cat `dpkg -L apt | grep copyright`'
+```
+**Result**:
+```
+Apt is copyright 1997, 1998, 1999 Jason Gunthorpe and others.
+Apt is currently developed by APT Development Team <deity@lists.debian.org>.
+
+License: GPLv2+
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA.
+
+See /usr/share/common-licenses/GPL-2, or
+<http://www.gnu.org/copyleft/gpl.txt> for the terms of the latest version
+of the GNU General Public License.
+```
+
+### Manually retrieve installed packages sources
+
+You can use the command `apt-get` to retrieve the source for any installed package.
+
+**Example**: To retrieve the source for the installed package `apt`:
+```bash
+docker run --rm ubuntu:22.04 bash -c 'dpkg-query --print-avail apt'
+```
+**Result**:
+```
+Package: apt
+Priority: important
+Section: admin
+Installed-Size: 4156
+Origin: Ubuntu
+Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
+Bugs: https://bugs.launchpad.net/ubuntu/+filebug
+Architecture: amd64
+Version: 2.4.5
+...
+SHA256: 89b093ec665072b3400881120aa3f4460222caa6a5d6c6ccb3d016beb18e7a00
+SHA512: 5d4e2b80ed0262dcfa9cbc3ca45e663e8e3e080691603eb464c035ad3785c595ca8915b2436ee43242b6cc904c2fd0c0a81ddd902cc2e04fb56f5afa9c1fc2b0
+Task: minimal, server-minimal
+Description-md5: 9fb97a88cb7383934ef963352b53b4a7
+Build-Essential: yes
+```
+
+### Manually retrieve installed files
+
+You can use the command `docker` to extract the contents of a container for further inspection.
+Here we show 2 common methods to extract the image contents without running the container.
+
+#### Method 1: Using a temporal container image to extract the files
+
+Create a temporal container image based on the image you want to inspect, and export its whole filesystem (or parts of it).
+
+**Example**:
+
+1. Create a temporal container image called `temp-container`, based on the `unknown-image:latest` image:
+    ```bash
+    docker create --name temp-container unknown-image:latest
+    ```
+
+2. Extract the whole container image filesystem as a TAR file:
+   ```bash
+    docker export temp-container > temp-container.tar
+    ```
+
+    Or, if you want to list only the included files:
+    ```bash
+    docker export temp-container | tar t > temp-container-files.txt
+    ```
+
+This method is a direct way to extract the image's final filesystem. 
+It provides a **composite view of a container instance's filesystem**.
+
+**Note**: This is the fastest way to list the included files or extract individual files.
+
+#### Method 2: Extract the container image layers as a set of layers
+
+Create a TAR file with all the individual image layers that compose the final container image.
+
+**Example**:
+
+- Use the command `docker image save` to create a TAR file containing all the container image layers:
+    ```bash
+    docker image save unknown-image:latest > temp-image.tar
+    ```
+
+The TAR file includes a `manifest.json` file, which describes the image's layers and a set of separate directories containing the content of each of the individual layers.
+
+This method produces an archive that exposes the container image format, not the container instances created from it.
+It provides a **layered view of the container image**.
+
+**Note**: This is useful when you want to evaluate each layer's role in building the image.
+
+#### Layered view vs composite view
+
+The following diagram illustrates the differences between the layered view and the composite view of a container image. 
+
+![](container-image-views.png)
+
+References:
+- For more information on the docker command arguments, see the [Docker CLI](https://docs.docker.com/engine/reference/commandline/docker/) documentation.
+- For more information on the container image format, see the [OCI image format specification](https://github.com/opencontainers/image-spec/blob/main/spec.md).

--- a/charts/msg-ems-tp/docs/container-image-views.png
+++ b/charts/msg-ems-tp/docs/container-image-views.png
@@ -1,0 +1,96 @@
+‰PNG
+
+
+¥R)
+*ØF¬¥líe+Z
+Åýû÷Åòû÷ïK­T©ÒóçÏõŒ¶IaoÚ´Ij¡wïÞba—.]¤Âˆˆ±°W¯^RáæÍ›õôâþýûÞÞÞÒPüöÛo¹¹¹ûöí“†ÂÛÛ;--ÍŒ}ÆŒýGgÏžK‹¼ÿþûW®\ÉËË»yóæ–-[Ú·o_üîxyyýöÛoééé|ðTØ®];“Þ2&õTWk&EeÙ÷‘ÆDëããsàÀ§OŸ~üñÇªåÞÞÞûöí{úôéÄ‰¥ÂŽ;š1nªo^_ý5''ç—_~©T©Rñßb(?jÔ¨!í-·nÝ2X¿8Ÿ-f¿/T+W©ReïÞ½j+uttLNN6#ÂH-/X° ==ýÑ£G'Ožœ?~ÝºuU;nÌ_s¸Šÿ¾c†5~gf†ÕÚScv]fXAÆ3,é™i"Õ³ØAAARùgŸ}&•Ï›7O,ŒŽŽ–
+{öì)Îœ9S*œ;w®ÔÂ¶mÛ¤òO?ýTk´ªåf´6zôh©ð‹/¾*«]AapF%U^µj•X¨ú?¿1cÆèm“Â~ôè‘ô/¥R™‘‘áàà ‚«««X~çÎ¥RY­Z5ñ©]zzºž.L™2EZ‘ôÿBµ¡˜:uªEöcö]>ýôS©~dddItçŸÿü§Xø×_I…îîîªí›Ñ}==ÕÕšIQYö}¤‡1Ñ®\¹R,LIIQ-ËïÝ»'zxx˜1nªoÞùóçKåóçÏ/þ[å‡‹‹‹´äææ¬_œÏ³ßª•u­TšeLŠ°bÅŠb‰]AAžŽóÆ×\Ê"ï;fX³1Ã*™aËþKzfø––6{öìfÍš‰—ÿËÁÁAµ¦ô¹ß¨Q#±PõR„øøx±0<<\*¼xñ¢ÔÂãÇ¥ò†jVú¡Ä¤ÖjÕª%^½zUª|õêU“>T/ÈîÚµ«X¨úÏ¶³gÏêmS¡Q£FRyjjªtÝ…t­ÅòåËUß·7Öß…Úµkk
+é"{AêÔ©cÆ>cÞþ£K½zõ¤úG-‰îHÿAÏËËÓÕMƒÝ7©§Æ¬Å`T–}éaL´)))Z£•zQTT¤zÕ„ã¦úæ½|ù²T~ùòe‹ŒŠïï¿ÿöòòÊÎÎ–J²³³===<xpíÚµ^½zùøø¸¹¹5oÞ|×®]Ö
+ÒÔô¬8Ÿ-f¿/T+ëšª^yå3"|é¥—¤ÂöíÛ/\¸pÏž=wïÞÕì¸y†yß1Ã‰VkOY3¬ ã–ôÌÀÁ…¤ÓÙº¨Ö÷Ýw¥òÛ·o§¤¤H—"x{{ççç‹ÕTgG]ÜÜÜ´F«9›šÔš“““T(]¡T*333‰ô½dGGÇÌÌÌÌÌLé¼p³fÍŽ¶©ƒ zF{ëÖ­âD%Žª ¯¿þúO?ý$Õ™>}ºþø…‹‹‹©ûLqö­TêñãÇ%Ñ¼¼<±PínD³{jL¹Á¨,û>ÒÃ¤h,7cÜTß¼™™™Z7qqÆÑ½{÷ï¿ÿ^zºaÃñ_ò5úòË/?~üìÙ3ñÛçÖŠÐÔ‹-òÙbd¹ÖB]+uvv6#ÂI“&i}/Ô®]ûë¯¿.**Ò˜ÒÐ‡¡¥ÞwÌ°1ÃšÚšIQ1ÃjnââŒIHÏ´¿$ªÿ¬8p ø¶ÂÂB]‹Ÿ<yR*ŽŽ^ºt©ôô£>’ª©¾ÏÙiôGkRkºÒ³çÏŸ9&’Õ«WKõ7oÞ¬úÁ½víZƒ£mê ¨ÞShÄˆâA†¢T*‡&B…
+†"ÕQû†«þqÓ5®®®¦î3ÅÙ´*æäajwL-7¯§)·ìûH’ë…IãfêÿVLXÄæÍ›ß|óMéi‡¶lÙ¢T*ÝÝÝÿúë/kG§Tš~k«|¶¨êZ©ÁôLk„ùùùÓ¦MSû>‰D×ÅZÆtD3˜â¼ï˜ab†µÔZ,²™±-;Všåew†-¿³‘c'}=W„¿ÿþ[,T»òUm‘æÍ›‹å­ZµjÚ´©TíôéÓRÕ³äÆLØú£5©5K]Ü¨T*³²²¤îÝwß4hø¸råÊª×öèŠßÔAÈÉÉ‘Þ<Ò}·Äãž¸¸8ñi…
+ÄNNN999ú,…K/ÌØ4•Â¥7–Áî›ÚS‹”[ö}dÆ‚Å/7iÜBCC¥BÕKGt]zaêøÀ"rss½½½Åÿë¯¿¼½½ÅÿïNŸ>ÝÛÛ{Ô¨QëÖ­3òó%ä—_~‘vŒ–-[¬o•ÏÕBË^Ü(ÊËË;räÈ¿þõ¯1cÆIÕüüüÌîˆf0Åyß1ÃÄk©µXd2cZv¬4ËËîËïž šdKß+“>ª´úè£Äüñ‡ôóõë×WýÅ³îÝ»K·lÙRÌ Mj­C‡Òã;vH·oßnêz]\\¤‹9wïÞ½gÏññ!CŒù§‚©ƒàääÔ²eKñ±¸]*V¬Ø±cGA:vì(Î+/^¼+´nÝZõ!ZuëÖMz¬úUNÕ¡P­c3öM½{÷–/Y²ÄZÝQ½µÚÅß–ê©©,û>²
+“ÆíÍ7ß”«nV]õm`|Ê"GGÇ¾}û®_¿^„ï¾û®_¿~â–]¸páþýûCBBvîÜc­;uê$~r
+‚pôèÑ…jÖÉÌÌ:t¨ø¸>*õÓµÒöíÛ›aÅŠ[¶l9jÔ¨+V¨þP’ê÷FtÑÿah©÷3¬AÌ°Å=ƒl`)Ã3¬e³½2ÄÈAhÛ¶­TmÒ¤IOŸ>Ý³g®›lŠ
+
+
+4#::ZµNZZšt9¬‹‹Kllìýû÷³³³¯]»¶wïÞ)S¦Hÿ4&Z“Z»|ù²´zyyíß¿?//oÿþýžžžfìgÏžÕÜ©T¿"©'~SAù¿¿¸"üï½SÕ>Uo¬¤Ëýû÷½¼¼Äúâo¨EñoûkÆþ£ééÓ§ªÿÜ1bÄÕ«Wóóóoß¾½uëÖV­ZY¶;ºÊU¿¯²zõjµšÚS‹”[ö}¤GÉõÂ¤qKNN–¾|"½yýõWK½Å`üñ‡8¶¯¼òÊŸþ©YáæÍ›úï-VÒ?~¬ú½öwÞyçÈ‘#™™™YYYçÎ›?¾øu#±rI¶h-W-¬R¥Êo¿ý–——wàÀ)GGÇ+W®˜aíÚµgÍšuèÐ¡›7oæääddd|ùå—ÒºTO'š÷ahÁ÷3¬~Ì°y¯Yj2cZ0Z¥mÍ°¤g:‰ÕŽ9¢y§Õ_WÐº~þùçªìíí¥“ª’'N¼üòËÐŒVkwLjmõêÕÅüYjUª·¦¡uëÖúGÛì°•Jebb¢ê«Òma•ÿ{ÇaAN:eLðþù§t›`5ÕªUÓó+“FŽyû¦7n¨ž}Õ5JéŽ®rÕßÐ¬cjO-UnÙ÷‘.%×SÇÍÔÍ4õ-K	ŽŽ•J^ýõÝ»w?|ø033366Vú!)kyöìÙ°aÃ4w'­»G‰~¶h-×³‡‚ P(V¯^­Úˆñêé¯‡‡Ç‰'¬ÿÃPiÑ÷3¬Ì°¦®ÅÔrfXÁJ3lù›C¤šüñG‡\]]]\\7nüí·ß*í…<RpA÷/i<}úôË/¿lÛ¶­···½½½§§g:uzôèñÕW_]»vMW´ºzd|kJ¥òÀíÛ·wwwwuumÖ¬Ù¦M›Œ\‹&éö»¢6èíâ„ýâÅéßW‚ÊV•Jå½{÷¤œÓËËKõî[ú=~üxáÂ…-Z´¨R¥J…
+*W®Ü¼yóh~EØ¼ñ1cÿÑª  `ãÆ}úô	
+
+rvvvuu=z´Ú4Yüîè*/,,\²dIÃ†¥ŸÁ)Î;ÅRå&íBfh–h/LÝC:ôæ›oVªTIzófeeI•5ÏÉ˜ôƒ¥Ì›7ÏÁÁAúL¥R¹oß¾:TªTÉÛÛ»wïÞ7oÞ´vŒJ¥R™œœ<kÖ¬6mÚøúú:::º¸¸4mÚtüøñj?:\rŸ-ZËÕ
+7mÚÔ¼ysWWW77·:8p@³/FFxíÚµ¯¿þ:22²N:RÍÆO›6Mí$f*-÷¾c†Õ–VyaJ#˜ª  À××Wº„}ëÖ­ª7€<yRºQDD„êýc2JõT
+°vŒ€pq#€R&ŸÖ¾øM@“££c@@@¿~ý¦OŸNnÀR.\¸°iÓ¦}ûöÝ¹sçÁƒNNN~~~ýúõëÑ£‡þ»ð
+…¢uëÖ‚ üøãâ©m77·6mÚœ9sFlüöíÛÕªUÓÓ”hëÖ­¯½öš³³sÕªU‡–žž.-îããóî»ïV«VM­;bËâ__ßo¾ù&((¨R¥Jÿüç?ÿþûïwß}×ÃÃÃÏÏ/..N¬¯+Âüüü™3g¾ôÒK®®®={öLHHð÷÷7 gmÛ¶%CŒa“3£ž–Ÿ<y2zôè—_~¹råÊ={öLJJ2>rýëI™´Ü°ðÔ£4‚‘Õ
+
+
+Ô*¯[·®iÓ¦â‡£èþýûÞÞÞJ¥2..ÎÝÝ=%%EzéùóçNNNJ¥òÛo¿}ûí·uPTTäææ&>2dÈ¿þõ/=Mmß¾½K—.ªsLff¦«««´øÌ™3µ®ElY|0yòd±0;;[„_~ùE|úäÉGGG=®[·®M›6ª/õïßÿ³Ï>3XQQQ·nÝºuë–››;sæÌfÍšeffZac£ÜÓ3G*uL“LgZ1,¶­\ÍŒzZvww¿wïžÚRFF®§Y]#ÉLj«Jaê!=ƒí˜9sfÃ†Ïž=;{öìÀÀÀ„„±¼mÛ¶{÷îÕ¬ß²eË_ýUµ$++Kü ŽŽŽ~ï½÷T_JLL¬_¿¾R©üè£-Z$•¿xñbÕªUM›6õôôÏHKÿN¼råŠž¦Þxã;;»
+*ØÙÙÙÙÙ‰·œªR¥Š´øÅ‹µöTlY­Îùóç¥:IIIuêÔÑaëÖ­Õ>>¼sçNƒ)•ÊÜÜÜ:tîÜY©TŽ7®C‡ÖÞø(´Î‘ú/a:ÓŠa±aåmfÔÓr÷îÝ}}}GŒ±cÇ)k22r=ÍêIfR[U
+Sß=ƒí8~üx«V­ê×¯/^«Ð¤I±üôéÓ-Z´Ð¬úôé¦M›ªµÐ¨Q#Anß¾]·n]Õ—Îž=[¿~}ñÁ«¯¾*•GEEíÚµkùòå7nÜ(**Ú´iÓ+¯¼"¶——÷Ê+¯èi*111;;»°°ðÅ‹/^¼g‹Ç‹‹ççç×©SG3lÕ–óòò¤:IIIªÝ9{ölƒôD˜””$‘èÒ¥Kú<y299¹AƒçÏŸ?räˆÚ0Ö¢uÊ³r83êj9>>þßÿþw5Æ÷Î;ïH¯¹®fu$3iùañ©‡ô¶cÛ¶m§Nš1cÆ¶mÛ*V¬(^á-‚½½ýóçÏ5ë{xxäææJOçÌ™óÁ‚pûöí5j¨V–²óçÏ«~”¯Y³fÍš5Íš5«\¹rQQÑ×_-~”ÿþûï¯¿þºþ¦*V¬xóæM­}ùý÷ßÛ¶m«ë%±eéèÌ™3ª={V¼•®+T¨ ^)Ú»wïýû÷}}}õ&Â²eË¼víÚÀÀÀÞ½{ÇÄÄÌŸ?¿Ô·6
+L„¿þú+))©]»v7oÞ<yò¤®8
+£ª(£ž<yR·nÝ?þø#  ÀÚ±
+…ÂÈ“æ
+
+ªX±¢O¿~ý._¾¬º B¡Ø³gO«V­ªT©R¥J•~ýúÝ¾}{Û¶mMš4qvv
+
+š1cF~~¾jý-[¶¼þúë/½ô’››[·nÝ®\¹b0<µ_£ ?þø£¸”““SxxøâÅ‹_¼x!½zõêÕ=z¸¹¹½ôÒK¯¿þú–-[L
+zF
+G
+k‡`NxÅ{Á‚Ý»w·vÿÊ¶Ýyd²gvíÚuÑ¢EÖŽ
+”,ÎžÉNrrrß¾}½¼¼*W®Ü»wïG‰åû÷ïoÔ¨‘‹‹K:u~øáá¿ÿÀP(úÿ“¡µÁ6mÚlÜ¸QªsçÎ??¿§OŸÍ›7¯Fžžžï¿ÿ~VV–XA¡P¬^½ºzõêRº¥k¥?ÿüsåÊ•ÇçååõË/¿HåùùùcÇŽõòòªY³æ7ß|c°Ü<‰‰‰Í›7—žêêŽª¼¼¼Ñ£G{yy…„„ÄÆÆšôÿ³ÂÂÂ9sæV«V-66Vj0**ªZµj¾¾¾QQQyyyÒˆ}óÍ7õêÕsqq©[·î‘#GÖ®]êììÜ¼yó+W®˜TÍÈ-¥5B©ºv6ãw$±µØØØooïqãÆåççë/—HahRëê4÷yéža_¿~}xx¸««kóæÍ/\¸ Ð²eË'Ns— ÂÁm?˜³ð÷øMFÖßzåžø·þÄ•Y+×ççå~9q”‘Ëäç:¬ßƒÔ;S—­Ú˜¼è§ÝßüãWKŒVZ»ôgê"ú+¿xQ¸hì{‰¿ï4iæ¿Z{ìÂÇ_¯®Û´Å¿?ŸU"£/oŸ}öÙøñã'OžP©R¥6mÚHÇÅŸ.µÎ2ºšÕ<ŽT¦á'ýÇ?öññÉÈÈP-©ZµjFF†þjÖ¬yéÒ%±ÂºuëÄ.\Ð¼êGk/ôø3¡›zÐ¢9{j çØ@O;‚Ñ‡1ªTÛ4fÑ›®?cK‡­¥g}ÂüôÿY;@Ãúõë7vìØÔÔÔ””ÿ3fˆåƒž5kÖãÇãââvíÚ%ü÷$¯R©Ô¶Wkƒ³fÍš;wnQQ‘XgîÜ¹&LðððX¶lÙÁƒ8pãÆ‚‚‚9sæHíìÚµëøñãÒ"º¬X±bÜ¸q‚ Œ3Fzó‚°`Á‚äääsçÎ<xpóæÍËÍ“––V­Z5é©žîHæÍ›—’’rþüù„„S/u[¼xqBBÂ’’’¤Oœùóç_¼xñäÉ“‰‰‰çÎ[°`T÷îÝÛ¶m{øðáÀ»víÿË/¿<zô¨G~ø¡IÕŒÜRZ#4¸³¿#‰âãã>|öìÙ«W¯.\¸Ð`¹1Ã¨uuzöy=Ã·{÷îtéÒEuœýüüîÝ+Ãÿ“dâÖå‹N.®íûP*•·¯\2iYGGÿàšïNžuõt¢‘‹ì\»ÒÃË{ì‚˜—k†Ú;8xWókòFÇyâ­=ÿççkìí¦Ç®­Ý¸©“‹«£³Kõš¯¼Ñ§ÿ[~¶HûeëPgÿþýÐúRñ§K­³Œ®f5£$š“‹þãOOÏ¾}û®ZµJ*YµjÕÀ«T©"•hm¡S§N‡!55uüøñ™™™‚ >|¸S§NÆŽžIÐ˜	ÝÔƒÍÙS3
+v^Î=+z9;x9W,Ñ~ìµþ}öìYxxø_ý%B@@ÀÔ©S{õêU½zucZÐú’jƒM›6ŠŠ8pàµk×Úµk—œœìââR»vímÛ¶½òÊ+‚ üý÷ß¯½öÚíÛ·ÅÖnß¾¨¿G7oÞlÖ¬Ù;wœœœrssŽ?^£FAjÖ¬¹cÇŽ:uê‚páÂ…zõê‰áé*Wë‹ÖÕiÖtvvNOOwqqŸêêŽªÝ»w‡……	‚péÒ¥ððpã÷öZµjÅÇÇ×­[W­Á;wJ=êÕ«×õë×Å^Ü»wOÌ³³³]]]ïß¿ïëë+>õööÎÎÎ6¾š‘[Jk„÷“öL…BqñâE±¿/^ìÙ³§Ô_]åbãÒ­A›ôTÏ°k@ñ©ÿ=†ÒW
+ÓYY¤*18ÏþgþìÐ†[uëµgÃþþ+å½ÿÐ__uî.ÈË{xÿî®µ«îß¹õé6	FÌì“"ÛšûÅ+lÜ¼
+Å_dÊ[o~8wIÍzMZ‹`£‡:™™™NNNš/ºÔ:ËèjVÿq”Ú»ÀàñÃ•+W:uêtãÆ{{ûÂÂÂÐÐÐßÿ=00PjGk;vìøá‡6nÜ¸xñâ/¿ürÁ‚|ðÁ;ï¼óî»ïöèÑÃÈÁ1ø!¦:iª2õ E×°ë
+@ëd­«38UÛ4fÑ›®?cÍcêÔS–Ò3­åÅ¼ »O˜Ÿ§j­›˜˜8mÚ´¤¤$ñ¤y…
+
+A8}úôçŸžàéé¹|ùò.]ºÆ¥gºÜ¾}û´iÓ.^¼8xðàæÍ›?^Õ{ÙÙÙÙ½xñBl­¨¨Èà…S§NU»#ÈÔ©S¿øâAœ322ÄèÜÜ\ggg1<]åJkappðÞ½{kÖ¬)>ÕÕUÎÎÎOž<¯äÖ€.ªÁk-ÌÍÍ­R¥Šƒ®¼Bí©‘ÕŒÜRZ#4¸o˜´g*Šœœ­ýÕU®ÖS­A›ÖFŒök×®uîÜùÆFnnØ
+·mÛ¢–›™18ÆLè9hQ(“$ŒaKÝESWlºüŒÙè¥£,¥gåDVVV¥J•\]]SRRFŒ!•÷êÕ+))Iõ»¡‚ x{{_¾|Ù¼
+ÅÌ™3—,YòÉ'ŸHw=zôˆ#._¾œ}òäÉž={êjVóÍ³qãÆ×^{-((H*	Žˆˆ?—8qâÄ»wïÞ½{7**Jª£«Ü<Ý»wß²e‹ôTOw¤ø0iÒ¤{÷îÝ»woÒ¤Iºú¨õÃbØ°aãÇ¿yófZZÚ˜1c¤'L˜ššššš:aÂ]×Ü“‘[Jk„]û†Vz*K[pâÄ‰ƒ2XnLºV§kŸ7cØ·lÙ¢v1	
+¿ à”«ÿó<ÛH´ÌóÙgŸ}õÕW111©©©Ïž=KHHO[	–˜.µÎ2ºšÕz%Q›\Œ™d;vìøìÙ³¯¿þÚÍÍíÕW_U{UW;wž4iÒ»ï¾+Â AƒÆß¹sgÍÆMc&t‹´¨”IÆŒéŠM×_)„d$Ò3+Sü/A¾ýöÛéÓ§»»»·k×®mÛ¶RÍ¡C‡¾÷Þ{žžž³gÏO ‚0}úô-Zèÿ7ƒ®A¨P¡B­Zµ†*•Œ?>22²wïÞ>>>cÆŒ>|¸ñ}Y±b…f0zôè+V‚0kÖ¬5jÔ¯_¿M›6}úô‘*è*7Oß¾}ÿüóÏäädã»óÉ'ŸT¯^½nÝº­ZµêÔ©“ƒƒ–krŽ=Ú²eKÍò©S§¶hÑ¢mÛ¶5ª_¿¾Ô`íÚµ#"""""ÂÃÃgÍ*‘[u¹¥´F(Ñ³ohÒS922²uëÖõë×		™9s¦Árc‚Ôµ:]û¼©Ã~õêÕ'N¼õÖ[%±u€râÙãô‹'ÿÜp*Y:Õ³!ñê…ã<ËxlR;J¥ÒÎ®‚‘•[vë¹mõ
+kw]Ÿ6=úÄ­úÚÚQÈE­Zµ8P¯^½—_~yæÌ™}ô‘øRñ§K­³Œ®fµGIÔ&#'Ù¨¨¨¨¨¨©S§j¾¤«…N:ýý÷ßâoºôïß?--Mó¾ fŽ1ºEZÔÊ¤	cÆÇ‚tÅ¦ëÀ¯B2RYúîYIüˆu/È¶ºÈÈÈ”ÐékY¸pá‘#GvïÞmÆ²çÎëÕ«—æ%Žo¼ñÆìÙ³ÛµkgíÎÉ‘®Ï™É§[·n­[·ž>}ºµA©’ùni-f÷lçÚU7/ŸðÅÿ¤"Ë¦Œ­UÿU=?€¦:w¤¥ÜZ¿t~eŸÑŸ/ŒP—7gHßêµB#‡ªTãÉ£G7/ß±æ_Ÿ¯3fñR¸5HaAÁÜáœ\\z¾ÿapzŸ?yrùÔñ%àPÇ‚x;£øtøY–©ûj™ùYjXVQQÑêÕ«oÝºõÎ;ïX;Ówx­&Nœ8mÚ´¼¼¼I“&õêÕK³Â†¿J²Å¼€ªƒÛ~6í3µÂ7z÷ÿnÉ\ý¿O-}«‚½ƒw5¿]zô3ÑÈ•:8:þcÝæm«W|ñÑRï¸Vª^¯ÿø)F..˜õ3Ó&±wpøô??îÙ°fÝâ¹©7®	
+…Ÿ­ú¾ØúKñP|ü¬«Ìœ=+!¶ú/%ƒ
+EPPÐæÍ›#""¬‹õ-_¾|éÒ¥ùùù={ö\¶l™t_~£Œž=CùÄn©U1o¬™³ÕCÞÎ0[)øÙìõKˆ­~f
+Ehhhppðž={¬
+
+EYl\©T–\Ø
+k‡`štïÞÝÚQE&c+“0JÁ±cÇBCCËOMÕµk×E‹Y;
+
+…¢K—.j‡•#ÑZÁâñ›Ñ â¿ììì|}}ššjp©+W®ôéÓÇËË«R¥J­ZµÚ³gf¸¸¸-ZÔªUË²}´óÆVa¹ì…ºvíêîîîîîÞµk×óçÏK/=}útÆŒ¡¡¡...Õ«Wï×¯ßÑ£G‹Ù‘sçÎuíÚµäªôY6Õ‹ˆˆØ¾}»µ»
+
+«éé¦¢¢¢´´´…6mÚT¨û÷ï7x†M„´´´jÕªIO	fÞ¼y)))çÏŸOHH°àe]V[ÍEæÏŸñâÅ“'O&&&ž;wnÁ‚zb.fƒž5kÖãÇãââvíÚ¥uYUûöí<x°jÉ!CöíÛ'>~ýõ×GŽyôèQý_…Ò\©®^«£X§N:$Bjjêøñã333A8|øp§Nt‹Hõ«ëxzzöíÛwÕªURÉªU«X¥J#?´öT¢gCÇÅÅíÞ½ûÁƒ]ºtùðÃõŒ› ~~~÷îñ;“
+ÏÞúú—#ú©ß¢µæ«Ò_`híwÓ ñ»®¥K}|5ýù£ì¼â÷ºøƒ¦¿ÂÓ§O_~ùeñq“&M¾ÿþ{¥R™œœìïïŸ••¥T*ÃÂÂ®\¹"VHKK”Z¾}û¶þ•N™2eÆŒFF¢µ‚ rTzñâEññ…BBBÄÇ!!!R¹ø] ý}T« «wj1¨ªR¥Ê…ô÷ÅÞÞ>''ÇàÖqrrÙø`‚ƒƒ/_¾,>¾xñ¢Iï,µÊ2[µÞ©®QŠDÏ"f‡Q½zõ¯¾úêÎ;U¨PAm›fggÛÛÛKÌž=»AƒNNNÁÁÁS¦Lyòä‰f#ZWª«×‚¶ôL©Tnß¾ýwÞQ*•‹-òññù÷¿ÿ­T*ÅËüô‹êÖàÖ¹|ùr@@@AAR©,((¨Q£†¸¸‘ú‡WO—ïß¿/>ÎÊÊrvvÖÓšXÇÅÅEYº,2
+
+AØ¾}û´iÓ.^¼8xðàæÍ›?^Õvvv/^¼[.**Òu?q¥ùùùÍ›7_¾|y«V­î+VÌÌÌTý²Mnn®«««´ºœœ'''±¼J•*bTÎÎÎR¹x<§§jaèê®1|øðáòåË;¶ÿ~=}ñõõýã?‚ƒƒõoààà½{÷Ö¬YÓø`œŸ<y"Ž’jÍØ¤§2[Í5J‘h]¤˜aœ>}úóÏ?OHHðôô\¾|y—.]½ŸTU«Výã?BBB¤’7n´jÕêþýûªÕŠŠŠ._¾¼dÉ’Giž5ÒºR]½VFõñóçÏÃÃÃSRRê×¯¿páÂ=z400ðâÅ‹nnnz†EõkÌÖéÚµëÐ¡Cßyç7îÜ¹óûï¿Œþ@Ð?¼ÆtYõ©ÖÖA¸víZçÎoÜ¸aä[À",2
+kÓù”å»Ö«ûãòÅÖJvú÷ï?tèÐë×¯>~üX:,‹ŒŒtttœ1cÆ±cÇFŽ)ÜºuKJÇUá~ñ©bÅŠß}÷ÝÈ‘#Ÿ={f0ªš5kž9sFµäÌ™3ÒÓ[·n‰nÞ¼éïï/>ö÷÷—ÊUÒtõQ-f=½ÓÊÇÇgÚ´iÇŽÓ_­}ûö›6m2ØåˆˆÕûûŒŸŸŸê8\…*''§ììlñqZZšêKÖ[µEüüü¤N]¿~]ŠD«b†Ñ¨Q£øøø‡ÆÄÄ¼ÿþûZ—UÛ¦ë×¯W-ùî»ïÚ·o¯VÍÎÎ.<<|Ù²e‡ÖlDëJéµj`nnnÁÁÁ?ýô“³³s·nÝ
+·mÛâææ¦gXÔ1fëDEE-_¾\„åË—O™2Åà‚ªíkí©yZOkG5x¥1
+'N¼{÷îÝ»w'Nœ8hÐ ±pàÀRyTT”Á>z{{«Þ°ÄÔÞ¥§§/Y²¤AƒúûòÙgŸ}õÕW111©©©Ïž=KHHþß¯ª{÷î[¶l1&i-˜4iÒ½{÷îÝ»7iÒ$]£ª5ªÆ/]º4++ëÖ­[£FýÏ-s¬5¶j‹0`Â„	©©©©©©&LÐÿý½b†Ñ«W¯¤¤$Õûph.«êÓO?]±bELLLZZZZZZLLLll¬ôÍ«fÍšmØ°áæÍ›ùùù·nÝš>}z«V­4ÑºRcz­XçÎ'Mšôî»ï
+‚0hÐ ñãÇwîÜYÿ°¨1fëtìØñÙ³g_ýµ››Û«¯¾jü‚ºzjÞ†ÖÓÚ–-[zôè!
+8''gäÈ‘UªT©Q£Ftt´ƒƒƒf]Q?¾Y³f...µk×þî»ï•ïžYklÕÉÉÉ?~|ÕªU«V­:~üx­ßß³Tqqq4pvv~õÕW8 uY5gÏžíÜ¹³«««««k§NÎœ9#½tôèÑ·ß~ÛßßßÉÉ©FcÇŽMOO×lAëJuõZ5µÀ’’’ìíí<x T*ÿþûo{{{)]Ã¢Ö)c¶ŽR©ü÷¿ÿmgg÷ë¯¿\P­}­=5¸¡_ÔÚÚ•+W|||²³³•¥ËêŸê
+
+ÒRn­_:¿²ÏèÏ—êZ¤ /oÎ¾Õk…FU-¨Æ“Gn^:¿cÍ¿>_WÌh¥ŠßñÒ9`À
+*mÞ¼Y†¹T5iÒ$??¿gÏžóæÍ³v8
+
+OíU
+kÇ/¯H”J¥µC
+
+AØ¾}û´iÓ.^¼8xðàæÍ›?^ÕÛ»ÙÙÙ½xñBl¹¨¨HÏuw<xð÷ßß¦MýAN:UíŽ S§Nýâ‹/ApvvÎÈÈprr!77×ÙÙYìŽ®rƒ}7u¬t©V­Ú¡C‡BCC¶¼wïÞš5kŠOu§*ggç'Ož8::êé.j#S¥JquºŽ³Õžš±¹Õ^ÒÕ‚®MfLzVœöõŽTGO¯srr4SO}­}1c½Û1~Û>}úóÏ?OHHðôô\¾|y—.]Ä
+×®]ëÜ¹ó7ôìN·Žž­f°fppð;ï¼#žà5¸jAîÜ¹Ó¬Y³âœñ3²›
+‚àïïëÖ-±¦êq¤®òRÓ©S§5kÖS3""âèÑ£ÒS=ã)ñóó“zwóæM“óóó“¹~ýº¿¿¿øØÈ/°™·¹U_ÒÕ‚®Mæää$žN!--Íâí«ÒUGO¯U7„4˜ÆlÄb®W«êÕ«‹§ïLÚv5ŠøðaLLÌûï¿/Õ?zôhÓ¦Mõ¯Ñ˜­c¶C‡mÞ¼yÉ’%FÖ_½zu‡,
+ÅÌ™3—,YòÉ'Ÿ8þ÷\âèÑ£GŒqùòåììì“'OöìÙÓ`ûÑÑÑüñ¾}û4þ4ñ7nÜøÚk¯©Þ-888""bÓ¦M‚ 8pâÄ‰wïÞ½{÷nTT”TGW¹‘LºÙ†ÖÊÿøÇ?¾ûî»)S¦\¾|9'''##C×Ý)»wï¾eËé©žñ”V4`À€I“&Ý»wïÞ½{“&MÒŒÖÀ0aÂ„ÔÔÔÔÔÔ	&0@,÷öö¾|ù²ÁÎš±¹lA×&kÜ¸ñÒ¥K³²²nÝº5jÔ(‹·¯JW=½–êOœ8qÐ Aæ’ëÕjØ°aãÇ¿yófZZÚ˜1cŒ™^½z%%%©Þ$F´eË–=zHOµîN¦n“¼üòË‡úöÛo¥/õi•””õí·ßÎ;WÀ
+jÕª5tèP©düøñ‘‘‘½{÷öññ3fÌðáÃ®qòäÉwîÜ©S§Ž´ÒçÏŸëª¼bÅ
+­š+V¬aÖ¬Y5jÔ¨_¿~›6múôé#UÐUn°ï‚ =z´eË–FŽž®ÊÇŽËÈÈèÐ¡ƒø»LkÖ¬ùã?4köíÛ÷Ï?ÿLNN6~<?ùä“êÕ«×­[·U«V:urpp0>°O>ù¤víÚááá³fýÿ»NŸ>½E‹hÍØÜF¶ k“ýë_ÿúùçŸ_zé¥nÝºõíÛ×âí«ÒUGO¯###[·n]¿~ý™3gš7Jf¬W«©S§¶hÑ¢mÛ¶5ª_¿¾‘#3tèÐ÷Þ{ÏÓÓsöìÙßÿ½XxõêÕ'N¼õÖ[âS]»“©[ÇT~~~\¿~ýçŸ®ùªø»gU«V}ï½÷“’’¸«>
+?ÿZõuy÷½ðúÅi¶¥gEEE«W¯þúë¯Ïž=k©_…†Ù&Nœ8mÚ´¼¼¼áÃ‡×¯_?::ÚÚYX™8 .A¢øØÐ
+‚‚‚6oÞLn&AAAMš4ÉÏÏïÙ³ç¼yó¬
+kÇ//Æ&
+
+u½
+
+7šiò²•_Fºxò˜µ
+R×
+Å7ß|S¯^=—ºuë9rdíÚµ¡¡¡ÎÎÎÍ›7¿råŠþ
+ƒ¿ÅüŸù³C6nÕ­×žÿùû¯”÷füCý>a~R›yyïßÝµvÕý;·>ý¾“o“"ÛšûÅ+›ÔyÕuI®ž9µrÎÇÑ;ö›:”Žì¼œ+z:Wôrvðr®hêâ¤vš¨J•*			ááájÕž={þ×_	‚0uêÔ^½zU¯^]ªP»vímÛ¶½òÊ+‚ üý÷ß¯½öÚíÛ·5×¥¹o¨¶Ü´iÓ¨¨¨^»v­]»vÉÉÉ...ºZV(·oßÔì”³³szzº‹‹‹ñ±…„„ìÞ½;,,L„K—.…‡‡åª½½ýóçÏœœ¤’œœœJ•*ˆ\ºtéŽ;®^½êçç×»wïO>ùÄÃÃCsp.^¼X§NA.^¼Ø³gOéòÈÚ
+
+…âÞ½{b›íêêzÿþ}___ñ©··wvv¶ž
+úë´ìÖsÛêÅ¹èÅ‹ŸVD·êöVÉKé~ú,44ôìÙ³6lË¿ýöÛéÓ§»»»·k×®mÛ¶Rý¡C‡¾÷Þ{žžž³gÏþþûïÅÂñãÇGFFöîÝÛÇÇgÌ˜1Ã‡×³F]-‚P¡B…Zµj:T*1©eQß¾}ÿüóÏäädã[øä“OªW¯^·nÝV­ZuêÔÉÁÁA³ÎÑ£G[¶l©YþÊ+¯ìß¿ïÞ½5kÖ¬Y³æ¯¿þºoß¾ÐÐPñÕèèè;w¶iÓÆÃÃ£}ûööööÒ«‰ŒŒlÝºuýúõCBBfÎœYÒ[ÁHºÐ5bºb¸zõê‰'Þz«Ì¿_
+&Nœ8mÚ´¼¼¼áÃ‡×¯_?::ÚÚC"wŒlé
+×›
+íÕ
+…µã—/c

--- a/charts/msg-ems-tp/docs/ems-baseOS-tps-software.md
+++ b/charts/msg-ems-tp/docs/ems-baseOS-tps-software.md
@@ -1,0 +1,19 @@
+# Partial listing of third party software and licenses
+
+This table displays a partial listing of some core third party software components that are used in this project.
+
+**Note**: This is not a complete list; it is provided to identify some of the most known components.
+
+| Third Party Software | Required       |   License   | License URL                                                 |
+|:---------------------|----------------|:-----------:|:------------------------------------------------------------|
+| Ubuntu               | required       | GPL2        | https://ubuntu.com/legal/open-source-licences?release=jammy | 
+| Fluent bit           | required       | Apache 2.0  | https://github.com/fluent/fluent-bit/blob/master/LICENSE    |
+| Golang               | required       | BSD-3       | https://github.com/golang/go/blob/master/LICENSE            |
+| immortal             | required       | BSD-3       | https://github.com/immortal/immortal/blob/master/LICENSE    |
+| Kubernetes           | required       | Apache 2.0  | https://github.com/kubernetes/kubernetes/blob/master/LICENSE|
+| Helm                 | required       | Apache 2.0  | https://github.com/helm/helm/blob/main/LICENSE              |
+| Openjdk              | required       | GPL2        | https://github.com/openjdk/jdk/blob/master/LICENSE          |
+| curl                 | recommended    | BSD-3       | https://ubuntu.com/legal/open-source-licences?release=jammy |
+| netcat               | recommended    | BSD-3       | https://ubuntu.com/legal/open-source-licences?release=jammy |
+| jq                   | optional       | MIT         | https://github.com/jqlang/jq                                |
+| Python               | optional       | BSD         | https://github.com/python/cpython/blob/main/LICENSE         |

--- a/charts/msg-ems-tp/templates/_dp.helpers.tpl
+++ b/charts/msg-ems-tp/templates/_dp.helpers.tpl
@@ -133,7 +133,7 @@ note: tib-msg-stsname will be added directly in statefulset charts, as it needs 
 */}}
 {{- define "msg.dp.labels" }}
 tib-dp-release: {{ .Release.Name | quote }}
-tib-dp-msgbuild: "1.0.0.22"
+tib-dp-msgbuild: "1.0.0.23"
 tib-dp-chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
 tib-dp-workload-type: "capability-service"
 tib-dp-dataplane-id: "{{ .Values.global.cp.dataplaneId | default "local-dp" }}"

--- a/charts/msg-ems-tp/templates/_ems.dp.helpers.tpl
+++ b/charts/msg-ems-tp/templates/_ems.dp.helpers.tpl
@@ -14,7 +14,7 @@ need.msg.ems.params
 */}}
 {{ define "need.msg.ems.params" }}
 {{-  $dpParams := include "need.msg.dp.params" . | fromYaml -}}
-{{-  $emsDefaultFullImage := printf "%s/%s/msg-ems-all:10.2.1-8" $dpParams.dp.registry $dpParams.dp.repo -}}
+{{-  $emsDefaultFullImage := printf "%s/%s/msg-ems-all:10.2.1-9" $dpParams.dp.registry $dpParams.dp.repo -}}
 {{-  $opsDefaultFullImage := printf "%s/%s/msg-dp-ops:1.0.0-2" $dpParams.dp.registry $dpParams.dp.repo -}}
 # Set EMS defaults
 {{- $name := ternary .Release.Name .Values.ems.name ( not .Values.ems.name ) -}}

--- a/charts/msg-ems-tp/values.yaml
+++ b/charts/msg-ems-tp/values.yaml
@@ -1,13 +1,13 @@
 #
 # Copyright (c) 2023. Cloud Software Group, Inc.
-# This file is subject to the license terms contained 
-# in the license file that is distributed with this file.  
+# This file is subject to the license terms contained
+# in the license file that is distributed with this file.
 #
 
-global: 
-  cp: 
-    dataplaneId: 
-    instanceId: 
+global:
+  cp:
+    dataplaneId:
+    instanceId:
 
 dp:
   # CAUTION: Values set here will override .global.cp.*
@@ -30,10 +30,10 @@ ems:
     promTopicsEP: 9093
     watchdogPort: 12502
     loggerPort: 12506
-  msgData: 
+  msgData:
     storageType: emptyDir
     storageName: none
-  logs: 
+  logs:
     storageType: useMsgData
     storageName: none
   sslEnable: true

--- a/charts/msg-ems-tp/values.yaml
+++ b/charts/msg-ems-tp/values.yaml
@@ -1,13 +1,13 @@
 #
 # Copyright (c) 2023. Cloud Software Group, Inc.
-# This file is subject to the license terms contained
-# in the license file that is distributed with this file.
+# This file is subject to the license terms contained 
+# in the license file that is distributed with this file.  
 #
 
-global:
-  cp:
-    dataplaneId:
-    instanceId:
+global: 
+  cp: 
+    dataplaneId: 
+    instanceId: 
 
 dp:
   # CAUTION: Values set here will override .global.cp.*
@@ -30,10 +30,10 @@ ems:
     promTopicsEP: 9093
     watchdogPort: 12502
     loggerPort: 12506
-  msgData:
+  msgData: 
     storageType: emptyDir
     storageName: none
-  logs:
+  logs: 
     storageType: useMsgData
     storageName: none
   sslEnable: true


### PR DESCRIPTION
msgdp-260: Add license.txt to image and analyze-TPS readme to chart

### Motivation
* Legal Container image review feedback

### Modifications
* Updated image with PIMS generated license.txt file
* Update chart with analyze thirdparty howto based on  spotfire CDK for Ubuntu base images

### Verifying this change
* updated test check_eua.sh
* Review chart package for new MD files
* msgdp PR = https://jira.tibco.com/browse/MSGDP-260