### PR TITLE
msgdp-263: protect png files from corruption as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.png binary


### PR DESCRIPTION
msgdp-263: protect png files from corruption as binary


Currently file: charts/msg-ems-tp/docs/container-image-views.png is corrupted.

Need this before attempting to repair.