### PR TITLE
jaeger es password update

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.23
+version: 0.71.24
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -492,7 +492,7 @@ Elasticsearch related command line options
 {{- define "elasticsearch.cmdArgs" -}}
 - --es.server-urls={{ .Values.global.cp.resources.o11y.tracesServer.config.es.endpoint }}
 - --es.username={{ .Values.global.cp.resources.o11y.tracesServer.config.es.username }}
-- --es.password={{ quote .Values.global.cp.resources.o11y.tracesServer.secret.es.password }}
+- --es.password={{ .Values.global.cp.resources.o11y.tracesServer.secret.es.password }}
 {{- range $key, $value := .Values.storage.elasticsearch.cmdlineParams -}}
 {{- if $value }}
 - --{{ $key }}={{ $value }}


### PR DESCRIPTION
[TPSEC-8](https://jira.tibco.com/browse/TPSEC-8)
Remove Elasticsearch (ES) Password Value from CP-tp-cp-orchestrator Logs After o11y Configuration on Data Plane

> Not to expose passwords in CP logs. 
> This is already resolved with 1.0.1 branch. This PR is to remove the quote in es.password argument in jaeger deployments