### PR TITLE
PDP-1525: Correct the API permission

### DIFF
--- a/docs/dp-cluster-workshop/aks/README.md
+++ b/docs/dp-cluster-workshop/aks/README.md
@@ -67,7 +67,7 @@ The steps are run with a Service Principal sign in.
 The Service Principal has:
 * Contributor role assigned over the scope of subscription used for the workshop
 * User Access Administrator role assigned over the scope of subscription used for the workshop
-* API permissions for Directory.Read.All and ServicePrincipalEndpoint.Read.All for the AAD role to propagate
+* Microsoft Graph API permission for Directory.Read.All of type Application for the AAD role to propagate
 
 You will need to [create a service principal with these role assignments](https://learn.microsoft.com/en-us/cli/azure/azure-cli-sp-tutorial-1?tabs=bash) with the above roles and permissions.
 


### PR DESCRIPTION
As discussed with Azure support on Case 2311150030003820, we can use lower set of permissions to create a cluster. This diff documents it.


Service Principal: workshop-sp-application-dir
Login Command: 
az login --service-principal --tenant cde6fa59-abb3-4971-be01-2443c417cbda --username f56f0b02-db4e-44e7-af1d-4962e9185b0c --password <password> --output table

